### PR TITLE
make source plain ascii

### DIFF
--- a/neurio/__init__.py
+++ b/neurio/__init__.py
@@ -443,7 +443,7 @@ class Client(object):
     specified with the request.
 
     Note:
-      This endpoint uses the location’s time zone when generating time intervals
+      This endpoint uses the location's time zone when generating time intervals
       for the stats, which is relevant if that time zone uses daylight saving
       time (some days will be 23 or 25 hours long).
 
@@ -454,7 +454,7 @@ class Client(object):
       end (string): ISO 8601 stop time for getting the events of appliances.
         Cannot be larger than 1 month from start time
       granularity (string): granularity of stats. If the granularity is
-        ‘unknown’, the stats for the appliances between the start and
+        'unknown', the stats for the appliances between the start and
         end time is returned.;
         must be one of  "minutes", "hours", "days", "weeks", "months", or "unknown"
         (default: days)
@@ -500,7 +500,7 @@ class Client(object):
     specified with the request.
 
     Note:
-      This endpoint uses the location’s time zone when generating time intervals
+      This endpoint uses the location's time zone when generating time intervals
       for the stats, which is relevant if that time zone uses daylight saving
       time (some days will be 23 or 25 hours long).
 
@@ -511,7 +511,7 @@ class Client(object):
       end (string): ISO 8601 stop time for getting the events of appliances.
         Cannot be larger than 1 month from start time
       granularity (string): granularity of stats. If the granularity is
-        ‘unknown’, the stats for the appliances between the start and
+        'unknown', the stats for the appliances between the start and
         end time is returned.;
         must be one of  "minutes", "hours", "days", "weeks", "months", or "unknown"
         (default: days)


### PR DESCRIPTION
Non-ascii characters in the source could result in the following error
when importing the `neurio` module:

```
Non-ASCII character '\xe2' in file neurio/__init__.py on line 447,
but no encoding declared; see http://python.org/dev/peps/pep-0263/
for details
```

This can be fixed either by replacing all the characters with plain
ascii equivalents or by adding a file header to specify the source file
encoding.

This commit implements the first option (replacing non-ascii characters
with ascii equivalents).

(Closes #3)
